### PR TITLE
Fix bio link inheritance problem so that _handleTap can be used

### DIFF
--- a/bio-link-fld.js
+++ b/bio-link-fld.js
@@ -3,7 +3,8 @@ import "@polymer/paper-input/paper-input";
 import "@polymer/iron-icon/iron-icon";
 import "@polymer/iron-flex-layout/iron-flex-layout";
 import "@biopolymer-elements/bio-icons/bio-icons";
-import "./bio-link-mixin";
+
+import {BioLinkMixin} from "./bio-link-mixin";
 
 /**
  * `bio-link-fld` Description
@@ -13,7 +14,7 @@ import "./bio-link-mixin";
  * @demo
  *
  */
-class BioLinkFld extends PolymerElement {
+class BioLinkFld extends BioLinkMixin(PolymerElement) {
   static get properties() {
     return {
       /** A flag that indicates whether or not the field is editable. */


### PR DESCRIPTION
## Description
bio-link-fld file had imported bio-link-mixin but had never used it which resulted in breakage of the functionality of bio-link-fld. The links created using bio-link-fld was not clickable.

## Summary of Changes
- [X] Inherit BioLinkFld from BioLinkMixin so as to use _handleTap method called from BioLinkFld